### PR TITLE
Add `show_macros_in_webui` option like Shake Tune

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,7 @@ The values listed below are the defaults Auto Speed uses. You can include them i
 #validate_inner_margin: 20.0 ; Margin for VALIDATE inner pattern
 #validate_iterations: 50     ; Perform VALIDATE pattern this many times
 
+# show_macros_in_webui: False       ; Display macros in web UI (e.g. Mainsail, Fluidd)
 #results_dir: ~/printer_data/config ; Destination directory for graphs
 ```
 

--- a/autospeed/dummy_macros.cfg
+++ b/autospeed/dummy_macros.cfg
@@ -1,0 +1,27 @@
+# This file is used when the `show_macros_in_webui` option is enabled. It wraps
+# the native Python commands in macros so that they will show up in web UIs
+# like Mainsail and Fluidd.
+
+[gcode_macro AUTO_SPEED]
+gcode: _AUTO_SPEED {rawparams}
+
+[gcode_macro AUTO_SPEED_VELOCITY]
+gcode: _AUTO_SPEED_VELOCITY {rawparams}
+
+[gcode_macro AUTO_SPEED_ACCEL]
+gcode: _AUTO_SPEED_ACCEL {rawparams}
+
+[gcode_macro AUTO_SPEED_VALIDATE]
+gcode: _AUTO_SPEED_VALIDATE {rawparams}
+
+[gcode_macro AUTO_SPEED_GRAPH]
+gcode: _AUTO_SPEED_GRAPH
+
+[gcode_macro X_ENDSTOP_ACCURACY]
+gcode: _X_ENDSTOP_ACCURACY {rawparams}
+
+[gcode_macro Y_ENDSTOP_ACCURACY]
+gcode: _Y_ENDSTOP_ACCURACY {rawparams}
+
+[gcode_macro Z_ENDSTOP_ACCURACY]
+gcode: _Z_ENDSTOP_ACCURACY {rawparams}


### PR DESCRIPTION
This option wraps the native python commands in macros so that they will display in web UI's like Mainsail and Fluidd. This implementation was adapted from https://github.com/Frix-x/klippain-shaketune as implemented by @Frix-x